### PR TITLE
kubernetes-debug

### DIFF
--- a/kubernetes-debug/kit/deploy/cr.yaml
+++ b/kubernetes-debug/kit/deploy/cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"

--- a/kubernetes-debug/kit/deploy/crd.yaml
+++ b/kubernetes-debug/kit/deploy/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: netperfs.app.example.com
+spec:
+  group: app.example.com
+  names:
+    kind: Netperf
+    listKind: NetperfList
+    plural: netperfs
+    singular: netperf
+  scope: Namespaced
+  version: v1alpha1

--- a/kubernetes-debug/kit/deploy/operator.yaml
+++ b/kubernetes-debug/kit/deploy/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: netperf-operator
+  template:
+    metadata:
+      labels:
+        name: netperf-operator
+    spec:
+      containers:
+        - name: netperf-operator
+          image: tailoredcloud/netperf-operator:v0.1.1-742a3e1
+          command:
+          - netperf-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes-debug/kit/deploy/rbac.yaml
+++ b/kubernetes-debug/kit/deploy/rbac.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: netperf-operator
+rules:
+- apiGroups:
+  - app.example.com
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-netperf-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: netperf-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/iptables-tailer-daemonset.yaml
+++ b/kubernetes-debug/kit/iptables-tailer-daemonset.yaml
@@ -1,0 +1,92 @@
+---
+  apiVersion: "apps/v1"
+  kind: "DaemonSet"
+  metadata: 
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec: 
+    selector:
+      matchLabels:
+        app: "kube-iptables-tailer"
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec:
+        serviceAccount: kube-iptables-tailer
+        containers: 
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+            env:
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal"
+                #- name: LOG_LEVEL
+                #value: info
+                #- name: "IPTABLES_LOG_PATH"
+                #value: "/var/log/kernel.log"              
+              - name: "POD_IDENTIFIER"
+                #value: "label"
+                value: "name"
+              #- name: "POD_IDENTIFIER_LABEL"
+                #value: "netperf-type"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+            #image: "boxinc/kube-iptables-tailer:v0.1.0"
+            image: "kube-iptables-tailer:v0.1.0"
+            imagePullPolicy: Never            
+            volumeMounts: 
+              - name: "iptables-logs"
+                mountPath: "/var/log/"
+                readOnly: true
+        volumes:
+          - name: "iptables-logs"
+            hostPath: 
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-iptables-tailer
+  namespace: kube-system
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-iptables-tailer
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["v1"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs:     ["patch","create"]
+  - apiGroups: ["v1"]
+    resources: ["events"]
+    verbs:     ["patch","create"]
+
+    
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-iptables-tailer
+subjects:
+  - kind: ServiceAccount
+    name: kube-iptables-tailer
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: kube-iptables-tailer
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/network-calico-policy.yaml
+++ b/kubernetes-debug/kit/network-calico-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+    - action: Allow
+      source:
+        #selector: netperf-type == "client"
+        #selector: app == "netperf-operator"
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny
+  egress:
+    - action: Allow
+      destination:
+        #selector: netperf-type == "client"
+        #selector: app == "netperf-operator"
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny

--- a/kubernetes-debug/strace/agent_daemonset.yml
+++ b/kubernetes-debug/strace/agent_daemonset.yml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: debug-agent
+  name: debug-agent
+spec:
+  selector:
+    matchLabels:
+      app: debug-agent
+  template:
+    metadata:
+      labels:
+        app: debug-agent
+    spec:
+      containers:
+      - image: aylei/debug-agent:v0.1.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10027
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: debug-agent
+        ports:
+        - containerPort: 10027
+          hostPort: 10027
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: docker
+          mountPath: "/var/run/docker.sock"
+      hostNetwork: true
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5
+    type: RollingUpdate

--- a/kubernetes-debug/strace/deployment-nginx.yaml
+++ b/kubernetes-debug/strace/deployment-nginx.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-status-page
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx-status-page
+  namespace: nginx-status-page
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx-status-page
+  template:
+    metadata:
+      labels:
+        app: nginx-status-page
+    spec:
+      containers:
+      - name: nginx
+        image: dimapl/nginx-alpine:3.3
+        ports:
+        - containerPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ № 23

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
### 1. Изучены debug методы с подключением к уже работающим контейнерам.
 - Запуск тестовой среды 
` minikube start --feature-gates="EphemeralContainers=true"`
 - Запускаем в качкстве тетового приложения nginx
`kubectl apply -f strace/deployment-nginx.yaml`
 - Встроенным в k8s debug-методом пытаемся выполнить debug контенера с nginx 
```
kubectl -n nginx-status-page -it debug  nginx-deployment-5f96b76859-zlgpr --image=bash --target=nginx 
Defaulting debug container name to debugger-54jv6.
bash-5.1# ps -ef
PID   USER     TIME  COMMAND
    1 root      0:00 nginx: master process nginx -g daemon off;
   32 101       0:00 nginx: worker process
   33 101       0:00 nginx: worker process
   34 101       0:00 nginx: worker process
   35 101       0:00 nginx: worker process
   36 101       0:00 nginx: worker process
   37 101       0:00 nginx: worker process
   38 101       0:00 nginx: worker process
   39 101       0:00 nginx: worker process
   40 root      0:00 bash
   48 root      0:00 ps -ef
bash-5.1# apk update
bash-5.1# apk add strace
bash-5.1# strace -p 1
strace: attach: ptrace(PTRACE_SEIZE, 1): Operation not permitted
bash-5.1# cat /proc/sys/kernel/yama/ptrace_scope
1
bash-5.1# echo 0 > /proc/sys/kernel/yama/ptrace_scope
bash: /proc/sys/kernel/yama/ptrace_scope: Read-only file system
```
 - Запускаем дополнительного kubectl-debug агента и получеам теже ошибки
```
kubectl apply -f strace/agent_daemonset.yml
kubectl-debug -n nginx-status-page  nginx-deployment-76d974d576-hrsvm
```
 - Находим в исходниках более новой версии kubectl-debug агента, что нужные нам cappability выставляются при создании пода агента. 
```
...
CapAdd:      strslice.StrSlice([]string{"SYS_PTRACE", "SYS_ADMIN"}),
...
```
 - Исправляем agent_daemonset.yml
```
      #- image: aylei/debug-agent:0.0.1
      - image: aylei/debug-agent:v0.1.1
```
`kubectl apply -f strace/agent_daemonset.yml`
 - Проверяем cappability
```
$ minikube ssh
root@minikube:/# docker ps -a |grep nicolaka
a5b06ae8db77   nicolaka/netshoot:latest   "bash"                   17 seconds ago   Up 16 seconds             focused_blackwell
root@minikube:/# docker inspect a5b06ae8db77 |grep SYS
                "SYS_PTRACE",
                "SYS_ADMIN"
```
 - Теперь трасировка доступна:
```
kubectl-debug -n nginx-status-page  nginx-deployment-76d974d576-hrsvm
bash-5.1# strace -c -p1
strace: Process 1 attached
```
### 2. Знакомство с инструментом kube-iptables-tailer, netperf и CNI calico
 - Запуск тестовой среды 
`minikube start --kubernetes-version=v1.21.3 --network-plugin=cni --cni=calico`
- Запускаем в качестве тестового придложения netperf утилиту:
```
$ kubectl apply -f ./netperf-operator/deploy/crd.yaml 
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
customresourcedefinition.apiextensions.k8s.io/netperfs.app.example.com created
$ kubectl apply -f ./netperf-operator/deploy/rbac.yaml 
Warning: rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
role.rbac.authorization.k8s.io/netperf-operator created
Warning: rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
rolebinding.rbac.authorization.k8s.io/default-account-netperf-operator created
$ kubectl apply -f ./netperf-operator/deploy/operator.yaml 
deployment.apps/netperf-operator created
$ kubectl apply -f ./netperf-operator/deploy/cr.yaml 
netperf.app.example.com/example created
```
 - Проверяем что netperf штатно отработал:
```
 $ kubectl describe netperfs.app.example.com example 
......
Spec:
  Client Node:  
  Server Node:  
Status:
  Client Pod:          netperf-client-ac683347b5f9
  Server Pod:          netperf-server-ac683347b5f9
  Speed Bits Per Sec:  5961.82
  Status:              Done
Events:                <none>
```
 - Устанавливаем огарничения по политикам calico, перезапускаем и проверяем netperf 
```
$ kubectl apply -f ./network-calico-policy.yaml
$ kubectl delete -f ./netperf-operator/deploy/cr.yaml 
netperf.app.example.com "example" deleted
$ kubectl apply -f ./netperf-operator/deploy/cr.yaml 
netperf.app.example.com/example created
$ kubectl describe netperfs.app.example.com example |grep Status
Status:
  Status:              Started test
```
 - Смотрим наличие событий на уровне iptables
```
$ minikube ssh 
root@minikube:/home/docker# iptables --list -nv | grep DROP
   55  3300 DROP       all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* cali:He8TRqGPuUw3VGwk */
root@minikube:/home/docker# iptables --list -nv | grep LOG 
   55  3300 LOG        all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* cali:B30DykF1ntLW86eD */ LOG flags 0 level 5 prefix "calico-packet: "
```
 - Однако на уровне логов, сообщений нет =(
`root@minikube:/home/docker# iptables --list -nv | grep DROP`
 - Включаем запись в журнал на ноде minikube
```
root@minikube:/home/docker# apt update
root@minikube:/home/docker# apt install vim
root@minikube:/home/docker# vim /etc/systemd/journald.conf 
#ReadKMsg=no
root@minikube:/home/docker# systemctl restart systemd-journald.service
``` 
 - Разрешаем ноде minikube писать из докера в журнал
`root@ubuntu18:~/kubernetes-debug/kit# echo 1 > /proc/sys/net/netfilter/nf_log_all_netn`
- Теперь записи об удалении пакетов логируются:
```
docker@minikube:~$ sudo journalctl -kf |grep calico-packet
Dec 03 15:07:25 minikube kernel: calico-packet: IN=cali74408fadd60 OUT=cali3b8d61efd0f MAC=ee:ee:ee:ee:ee:ee:e6:d1:73:6d:d7:e8:08:00 SRC=10.244.120.95 DST=10.244.120.94 LEN=60 TOS=0x00 PREC=0x00 TTL=63 ID=11632 DF PROTO=TCP SPT=40025 DPT=12865 WINDOW=28800 RES=0x00 SYN URGP=0 
Dec 03 15:07:26 minikube kernel: calico-packet: IN=cali74408fadd60 OUT=cali3b8d61efd0f MAC=ee:ee:ee:ee:ee:ee:e6:d1:73:6d:d7:e8:08:00 SRC=10.244.120.95 DST=10.244.120.94 LEN=60 TOS=0x00 PREC=0x00 TTL=63 ID=11633 DF PROTO=TCP SPT=40025 DPT=12865 WINDOW=28800 RES=0x00 SYN URGP=0 
```
- Собираем в doker внутри minikube новый image kube-iptables-tailer
```
git clone git@github.com:box/kube-iptables-tailer.git
eval $(minikube docker-env)
cd kube-iptables-tailer/
make container
minikube image ls
....
docker.io/library/kube-iptables-tailer:v0.1.0
...
```
kubectl apply -f ./kit/iptables-tailer-daemonset.yaml
 - Добавляем папку в ноде minikube
```
minikube ssh
root@minikube:/home/docker# mkdir /var/log/journal
docker@minikube:~$ sudo systemctl restart systemd-journald.service

```
- Ошибка в kube-iptables-tailer
```
dyplis@ubuntu18:~/kubernetes-debug$ kubectl logs -n kube-system kube-iptables-tailer-s4g7d 
{"level":"fatal","timestamp":"2021-12-02T15:54:55.290Z","caller":"drop/journal_watcher.go:11","msg":"you need to build with cgo for journal watching support","stacktrace":"github.com/box/kube-iptables-tailer/drop.InitJournalWatcher\n\t/go/src/github.com/box/kube-iptables-tailer/drop/journal_watcher.go:11\nmain.startJournalWatcher\n\t/go/src/github.com/box/kube-iptables-tailer/main.go:89"}
```
 - Собираем kube-iptables-tailer с поддержкой journald
```
minikube image rm docker.io/library/kube-iptables-tailer:v0.1.0
eval $(minikube docker-env)
cd kube-iptables-tailer/
make container-cgo
```
 - Добавляем в роль права на создание и исправление event'ов
 vim ./kit/iptables-tailer-daemonset.yaml
```
....
  - apiGroups: [""]
    resources: ["events"]
    verbs:     ["patch","create"]
...
kubectl apply -f ./kit/iptables-tailer-daemonset.yaml
```
 - Перезапускаем netperf и видим события удаления пакетов в events:
```
kubectl get -A events |grep "Packet dropped"
default       2m15s       Warning   PacketDrop                pod/netperf-client-17a548e6ae7c                Packet dropped when sending traffic to server (10.244.120.94) on port 12865/TCP
default       9m31s       Warning   PacketDrop                pod/netperf-server-17a548e6ae7c                Packet dropped when receiving traffic from 10.244.120.95 on port 12865/TCP
default       2m15s       Warning   PacketDrop                pod/netperf-server-17a548e6ae7c                Packet dropped when receiving traffic from client (10.244.120.95) on port 12865/TCP

kubectl describe pod --selector=app=netperf-operator |grep -A10  Events: 
Events:
  Type     Reason      Age                  From                  Message
  ----     ------      ----                 ----                  -------
  Normal   Scheduled   12m                  default-scheduler     Successfully assigned default/netperf-client-17a548e6ae7c to minikube
  Normal   Pulled      2m28s (x5 over 12m)  kubelet               Container image "tailoredcloud/netperf:v2.7" already present on machine
  Normal   Created     2m28s (x5 over 12m)  kubelet               Created container netperf-client-17a548e6ae7c
  Normal   Started     2m28s (x5 over 12m)  kubelet               Started container netperf-client-17a548e6ae7c
  Warning  PacketDrop  2m27s (x4 over 10m)  kube-iptables-tailer  Packet dropped when sending traffic to server (10.244.120.94) on port 12865/TCP
  Warning  BackOff     6s (x8 over 8m15s)   kubelet               Back-off restarting failed container
--
Events:
  Type     Reason      Age                  From                  Message
  ----     ------      ----                 ----                  -------
  Normal   Scheduled   12m                  default-scheduler     Successfully assigned default/netperf-server-17a548e6ae7c to minikube
  Normal   Pulled      12m                  kubelet               Container image "tailoredcloud/netperf:v2.7" already present on machine
  Normal   Created     12m                  kubelet               Created container netperf-server-17a548e6ae7c
  Normal   Started     12m                  kubelet               Started container netperf-server-17a548e6ae7c
  Warning  PacketDrop  12m                  kube-iptables-tailer  Packet dropped when receiving traffic from 10.244.120.95 on port 12865/TCP
  Warning  PacketDrop  2m27s (x4 over 10m)  kube-iptables-tailer  Packet dropped when receiving traffic from client (10.244.120.95) on port 12865/TCP
```
### ДЗ со ⭐
 - Добавляем в вывод Events имена pod'ов:
cat kubernetes-debug/kit/iptables-tailer-daemonset.yaml
...
               - name: "POD_IDENTIFIER"
                #value: "label"
                value: "name"
              #- name: "POD_IDENTIFIER_LABEL"
                #value: "netperf-type"
... 
 - Исправляем политики calico, чтобы netperf работал штатно и пакеты не drop'ались:
```
cat ./kit/network-calico-policy.yaml
   ingress:
    - action: Allow
      source:
        selector: netperf-type == "client"
        #selector: netperf-role == "netperf-client"
    - action: Log
    - action: Deny
  egress:
    - action: Allow
      destination:
        selector: netperf-type == "server"
        #selector: netperf-role == "netperf-client"
    - action: Log
    - action: Deny
```
 - Теперь netperf отработал штатно:
```
 kubectl describe netperfs.app.example.com example |grep Status
Status:
  Status:              Done
```

## Как запустить проект:
 - Для этого ДЗ требуется minikube в следующей конфигурации
` minikube start --feature-gates="EphemeralContainers=true" --kubernetes-version=v1.21.3 --network-plugin=cni --cni=calico`

## PR checklist:
 - [X] Выставлен label с темой домашнего задания
